### PR TITLE
fix: changing an image when using non :filesystem storage causes dimensions to be removed

### DIFF
--- a/lib/paperclip-meta.rb
+++ b/lib/paperclip-meta.rb
@@ -5,7 +5,7 @@ module Paperclip
 
     # If attachment deleted - destroy meta data
     def save
-      unless @queued_for_delete.empty?
+      if (not @queued_for_delete.empty?) and @queued_for_write.empty?
         instance_write(:meta, ActiveSupport::Base64.encode64(Marshal.dump({}))) if instance.respond_to?(:"#{name}_meta=")
       end
       original_save


### PR DESCRIPTION
only remove image dimensions if the @queued_for_write array is empty (otherwise changing an image using a non :filesystem storage causes dimensions to be wiped out)
