### PR TITLE
Compatibility with recent Paperclip

### DIFF
--- a/lib/paperclip-meta.rb
+++ b/lib/paperclip-meta.rb
@@ -14,7 +14,7 @@ module Paperclip
     # If model has #{name}_meta column we getting sizes of processed
     # thumbnails and saving it to #{name}_meta column.
     def post_process_styles(*style_args)
-      original_post_process_styles(style_args)
+      method(:original_post_process_styles).arity == 0 ? original_post_process_styles : original_post_process_styles(*style_args)
 
       if instance.respond_to?(:"#{name}_meta=")
         meta = {}


### PR DESCRIPTION
Paperclip::Attachment#post_process_styles gets arguments in recent Paperclip versions (at least in 2.4.5 and 2.5.0), so avoid "wrong number of arguments" errors
