### PR TITLE
Use file size of the io adapters

### DIFF
--- a/lib/paperclip-meta/attachment.rb
+++ b/lib/paperclip-meta/attachment.rb
@@ -33,7 +33,7 @@ module Paperclip
             @queued_for_write.each do |style, file|
               begin
                 geo = Geometry.from_file file
-                meta[style] = {:width => geo.width.to_i, :height => geo.height.to_i, :size => File.size(file) }
+                meta[style] = {:width => geo.width.to_i, :height => geo.height.to_i, :size => file.size }
               rescue NotIdentifiedByImageMagickError => e
                 meta[style] = {}
               end


### PR DESCRIPTION
It makes sense to use the io adapters size method to determine the file size instead of using File.size(file). I got an error when I tried to assign a file object to the attachment property of my model.

```
TypeError:
       can't convert Paperclip::FileAdapter into String
     # /Users/ms/.rvm/gems/ruby-1.9.3-p0@equis-domain/gems/paperclip-meta-0.4.1/lib/paperclip-meta/attachment.rb:36:in `size'
     # /Users/ms/.rvm/gems/ruby-1.9.3-p0@equis-domain/gems/paperclip-meta-0.4.1/lib/paperclip-meta/attachment.rb:36:in `block in post_process_styles_with_meta_data'
     # /Users/ms/.rvm/gems/ruby-1.9.3-p0@equis-domain/gems/paperclip-meta-0.4.1/lib/paperclip-meta/attachment.rb:33:in `each'
     # /Users/ms/.rvm/gems/ruby-1.9.3-p0@equis-domain/gems/paperclip-meta-0.4.1/lib/paperclip-meta/attachment.rb:33:in `post_process_styles_with_meta_data'
     # /Users/ms/.rvm/gems/ruby-1.9.3-p0@equis-domain/gems/paperclip-3.0.1/lib/paperclip/attachment.rb:376:in `block (2 levels) in post_process'
```

I think this only occurs since paperclip version 3.0.0 since there were no io adapters before that.
