### PR TITLE
Add Rails 2.3 compatible railtie

### DIFF
--- a/rails/init.rb
+++ b/rails/init.rb
@@ -1,0 +1,2 @@
+require 'paperclip-meta/railtie'
+Paperclip::Meta::Railtie.insert


### PR DESCRIPTION
This fixes issue #14.  Rails 2.3 apps weren't automatically getting Paperclip::Meta loaded.

No worries if you aren't looking to keep 2.3 compatibility but I thought I'd offer up the pull request anyway.
