### PR TITLE
Correctly include Paperclip::Glue

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ ActiveRecord::Base.establish_connection(
 ActiveRecord::Base.logger = Logger.new(nil)
 load(File.join(File.dirname(__FILE__), 'schema.rb'))
 
-Paperclip::Railtie.insert
+ActiveRecord::Base.send(:include, Paperclip::Glue)
 Paperclip::Meta::Railtie.insert
 
 class Image < ActiveRecord::Base


### PR DESCRIPTION
`Paperclip::Meta` should include `Paperclip::Glue` into ActiveRecord when testing, as `Paperclip::Railtie` is reserved to be used when there's a whole rails stack exists only.
