### PR TITLE
Replace Relation#update_all with conditions to use where().update_all

### DIFF
--- a/lib/paperclip-meta/attachment.rb
+++ b/lib/paperclip-meta/attachment.rb
@@ -41,7 +41,7 @@ module Paperclip
 
             unless meta == {}
               instance.send("#{name}_meta=", meta_encode(meta))
-              instance.class.update_all({ "#{name}_meta" => meta_encode(meta) }, instance.class.primary_key => instance.id)
+              instance.class.where(instance.class.primary_key => instance.id).update_all({ "#{name}_meta" => meta_encode(meta) })
             end
           end
         end


### PR DESCRIPTION
This corrects a deprecation warning and dependency on deprecated finders in Rails 4.0.0.beta.
