### PR TITLE
Rescue NotIdentifiedByImageMagickError for Paperclip versions < 3.0.0.

### DIFF
--- a/lib/paperclip-meta/attachment.rb
+++ b/lib/paperclip-meta/attachment.rb
@@ -34,7 +34,7 @@ module Paperclip
               begin
                 geo = Geometry.from_file file
                 meta[style] = {:width => geo.width.to_i, :height => geo.height.to_i, :size => file.size }
-              rescue Paperclip::Errors::NotIdentifiedByImageMagickError => e
+              rescue (Paperclip::VERSION < "3.0.0" ? Paperclip::NotIdentifiedByImageMagickError : Paperclip::Errors::NotIdentifiedByImageMagickError) => e
                 meta[style] = {}
               end
             end


### PR DESCRIPTION
The exception class `Paperclip::Errors::NotIdentifiedByImageMagickError` was introduced in Paperclip 3.0.0; in earlier versions it was `Paperclip::NotIdentifiedByImageMagickError`. 

This commit checks the Paperclip version and rescues the corresponding exception class.
