### PR TITLE
Remove redundant development dependency from gemspec

### DIFF
--- a/paperclip-meta.gemspec
+++ b/paperclip-meta.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   # Development depensencies
   s.add_development_dependency "bundler", ">= 1.0.0"
   s.add_development_dependency "rake"
-  s.add_development_dependency "paperclip"
   s.add_development_dependency "rspec"
   s.add_development_dependency "activerecord"
   s.add_development_dependency "activerecord-jdbcsqlite3-adapter" if RUBY_PLATFORM == 'java'


### PR DESCRIPTION
Since paperclip is defined as a runtime dependency, it does not need to
be defined as a development dependency.
