### PR TITLE
Preserve meta data

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,7 @@ class Image < ActiveRecord::Base
     storage: :filesystem,
     path: "./spec/tmp/fixtures/tmp/:style/:id.:extension",
     url: "./spec/tmp/fixtures/tmp/:style/:id.extension",
-    styles: { thumb: "100x100#" }
+    styles: { thumb: "100x100#", large: "500x500#" }
 
   # paperclip 4.0 requires a validator
   validates_attachment_content_type :small_image, content_type: /\Aimage/


### PR DESCRIPTION
For styles that were already processed or when a style is exclusively reprocessed, the meta data should remain.

This is @kshsieh's [PR](https://github.com/teeparham/paperclip-meta/pull/20), which I was using, cleaned up a bit in hopes that it'll be merged.
