### PR TITLE
README refers to image_size erroneously as size

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ style: {
 
 This hash will be marshaled and base64 encoded before writing to model attribute.
 
-`height`, `width`, and `size` methods are provided:
+`height`, `width`, and `image_size` methods are provided:
 
 ```ruby
 user.avatar.width(:thumb)
 => 100
 user.avatar.height(:medium)
 => 200
-user.avatar.size
+user.avatar.image_size
 => '60x70'
 ```
 


### PR DESCRIPTION
Note: I have not even tried the gem yet, but I was confused by this part, and looking at the code this seems like what was intended.

Of course since `size` is affected by the gem as well, a note could be added to mention that. I don't think that's required but it's a possibility if the mention of `size` on row 48 looks confusing still.
