### PR TITLE
Fix TypeError because sometimes original_meta is just a string representation of Hash

### DIFF
--- a/lib/paperclip-meta/attachment.rb
+++ b/lib/paperclip-meta/attachment.rb
@@ -93,6 +93,8 @@ module Paperclip
         def merge_existing_meta_hash(meta)
           return unless (original_meta = instance.send("#{name}_meta"))
           meta.reverse_merge! meta_decode(original_meta)
+        rescue TypeError
+          meta.reverse_merge! eval(original_meta)
         end
       end
     end


### PR DESCRIPTION
Based on the @laptite suggestions. Will fix #39.

I don't understand reasons for this error, so this fix may be incorrect or not complete. At least it helped me. @teeparham your thoughts?