### PR TITLE
Fix original image meta not being set during creation when using delayed_paperclip

### DIFF
--- a/paperclip-meta.gemspec
+++ b/paperclip-meta.gemspec
@@ -22,4 +22,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "mocha", "~> 1.0"
   s.add_development_dependency "activerecord", ">= 4.2"
   s.add_development_dependency "sqlite3", ">= 1.3.10"
+  s.add_development_dependency "delayed_paperclip", ">= 2.9.1"
+  s.add_development_dependency "activejob", ">= 4.2"
 end


### PR DESCRIPTION
We use [delayed_paperclip](https://github.com/jrgifford/delayed_paperclip) and paperclip-meta together in our Rails app. We want to return the original image with width and height when the other styles are being processed in the background. This PR makes it so that original image meta is set during creation.

More info: https://github.com/jrgifford/delayed_paperclip/#displaying-images-during-processing

Do you think this is a good addition?

Thanks for an excellent open source library!