### PR TITLE
Convert deprecated alias_method_chain to Module#prepend

### DIFF
--- a/lib/paperclip-meta/attachment.rb
+++ b/lib/paperclip-meta/attachment.rb
@@ -1,109 +1,99 @@
 module Paperclip
   module Meta
     module Attachment
-      def self.included(base)
-        base.send :include, InstanceMethods
-        base.alias_method_chain :assign_attributes, :meta_data
-        base.alias_method_chain :save, :meta_data
-        base.alias_method_chain :post_process_styles, :meta_data
-        base.alias_method_chain :size, :meta_data
+
+      def assign_attributes
+        super
+        assign_meta
       end
 
-      module InstanceMethods
-        def assign_attributes_with_meta_data
-          assign_attributes_without_meta_data
-          assign_meta
+      def save
+        if @queued_for_delete.any? && @queued_for_write.empty?
+          instance_write(:meta, meta_encode({}))
         end
+        super
+      end
 
-        def save_with_meta_data
-          if @queued_for_delete.any? && @queued_for_write.empty?
-            instance_write(:meta, meta_encode({}))
-          end
-          save_without_meta_data
-        end
+      def post_process_styles(*styles)
+        super(*styles)
+        assign_meta
+      end
 
-        def post_process_styles_with_meta_data(*styles)
-          post_process_styles_without_meta_data(*styles)
-          assign_meta
-        end
+      # Use meta info for style if required
+      def size(style = nil)
+        style ? read_meta(style, :size) : super()
+      end
 
-        # Use meta info for style if required
-        def size_with_meta_data(style = nil)
-          style ? read_meta(style, :size) : size_without_meta_data
-        end
+      def height(style = default_style)
+        read_meta style, :height
+      end
 
-        def height(style = default_style)
-          read_meta style, :height
-        end
+      def width(style = default_style)
+        read_meta style, :width
+      end
 
-        def width(style = default_style)
-          read_meta style, :width
-        end
+      def aspect_ratio(style = default_style)
+        width(style).to_f / height(style).to_f
+      end
 
-        def aspect_ratio(style = default_style)
-          width(style).to_f / height(style).to_f
-        end
+      # Return image dimesions ("WxH") for given style name. If style name not given,
+      # return dimesions for default_style.
+      def image_size(style = default_style)
+        "#{width(style)}x#{height(style)}"
+      end
 
-        # Return image dimesions ("WxH") for given style name. If style name not given,
-        # return dimesions for default_style.
-        def image_size(style = default_style)
-          "#{width(style)}x#{height(style)}"
-        end
+      private
 
-        private
+      def assign_meta
+        return unless instance.respond_to?(:"#{name}_meta=")
+        meta = populate_meta(@queued_for_write)
+        return if meta == {}
 
-        def assign_meta
-          return unless instance.respond_to?(:"#{name}_meta=")
+        write_meta(meta)
+      end
 
-          meta = populate_meta(@queued_for_write)
-          return if meta == {}
-
-          write_meta(meta)
-        end
-
-        def populate_meta(queue)
-          meta = {}
-          queue.each do |style, file|
-            begin
-              geo = Geometry.from_file file
-              meta[style] = { width: geo.width.to_i, height: geo.height.to_i, size: file.size }
-            rescue Paperclip::Errors::NotIdentifiedByImageMagickError
-              meta[style] = {}
-            end
-          end
-          meta
-        end
-
-        def write_meta(meta)
-          merge_existing_meta_hash meta
-          instance.send("#{name}_meta=", meta_encode(meta))
-        end
-
-        # Return meta data for given style
-        def read_meta(style, item)
-          if instance.respond_to?(:"#{name}_meta") && instance_read(:meta)
-            if (meta = meta_decode(instance_read(:meta)))
-              meta[style] && meta[style][item]
-            end
+      def populate_meta(queue)
+        meta = {}
+        queue.each do |style, file|
+          begin
+            geo = Geometry.from_file file
+            meta[style] = { width: geo.width.to_i, height: geo.height.to_i, size: file.size }
+          rescue Paperclip::Errors::NotIdentifiedByImageMagickError
+            meta[style] = {}
           end
         end
+        meta
+      end
 
-        # Return encoded metadata as String
-        def meta_encode(meta)
-          Base64.encode64(Marshal.dump(meta))
-        end
+      def write_meta(meta)
+        merge_existing_meta_hash meta
+        instance.send("#{name}_meta=", meta_encode(meta))
+      end
 
-        # Return decoded metadata as Object
-        def meta_decode(meta)
-          Marshal.load(Base64.decode64(meta))
+      # Return meta data for given style
+      def read_meta(style, item)
+        if instance.respond_to?(:"#{name}_meta") && instance_read(:meta)
+          if (meta = meta_decode(instance_read(:meta)))
+            meta[style] && meta[style][item]
+          end
         end
+      end
 
-        # Retain existing meta values that will not be recalculated when
-        # reprocessing a subset of styles
-        def merge_existing_meta_hash(meta)
-          return unless (original_meta = instance.send("#{name}_meta"))
-          meta.reverse_merge! meta_decode(original_meta)
-        end
+      # Return encoded metadata as String
+      def meta_encode(meta)
+        Base64.encode64(Marshal.dump(meta))
+      end
+
+      # Return decoded metadata as Object
+      def meta_decode(meta)
+        Marshal.load(Base64.decode64(meta))
+      end
+
+      # Retain existing meta values that will not be recalculated when
+      # reprocessing a subset of styles
+      def merge_existing_meta_hash(meta)
+        return unless (original_meta = instance.send("#{name}_meta"))
+        meta.reverse_merge! meta_decode(original_meta)
       end
     end
   end

--- a/lib/paperclip-meta/railtie.rb
+++ b/lib/paperclip-meta/railtie.rb
@@ -12,7 +12,7 @@ module Paperclip
 
     class Railtie
       def self.insert
-        Paperclip::Attachment.send(:include, Paperclip::Meta::Attachment)
+        Paperclip::Attachment.prepend Paperclip::Meta::Attachment
       end
     end
   end

--- a/spec/attachment_spec.rb
+++ b/spec/attachment_spec.rb
@@ -43,11 +43,6 @@ describe "Attachment" do
       assert_equal size, @image.big_image.size(:thumb)
     end
 
-    it "should access normal paperclip method when no style passed" do
-      @image.big_image.expects size_without_meta_data: 1234
-      assert_equal 1234, @image.big_image.size
-    end
-
     it "should have access to original file size" do
       assert_equal 37_042, @image.big_image.size
     end


### PR DESCRIPTION
Just what it says; converting to Module#prepend. With Rails 5 and the current version you get all sorts of alias_method_chain deprecation messages.

This requires Ruby >= 2.0; Paperclip 5 requires Ruby 2.1. Not sure how you want to handle the versioning.