### PR TITLE
Update to Module#prepend, and update specs to test against delayed_paperclip 3.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,8 @@ rvm:
   - 2.3.0
   - 2.2
   - 2.1
-  - 2.0.0
 gemfile:
-  - spec/gemfiles/Gemfile.paperclip-4
+  - spec/gemfiles/Gemfile.paperclip-5
 before_install:
   - gem update bundler
 install:

--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,5 @@ end
 gemspec
 
 gem "paperclip"
+# Temporarily depending on this fork for development
+gem 'delayed_paperclip', github: 'whatcould/delayed_paperclip'

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,5 @@ end
 # See paperclip-meta.gemspec
 gemspec
 
+gem 'activesupport', '~> 5'
 gem "paperclip"

--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,3 @@ end
 gemspec
 
 gem "paperclip"
-# Temporarily depending on this fork for development
-gem 'delayed_paperclip', github: 'whatcould/delayed_paperclip'

--- a/lib/paperclip-meta/attachment.rb
+++ b/lib/paperclip-meta/attachment.rb
@@ -1,109 +1,99 @@
 module Paperclip
   module Meta
     module Attachment
-      def self.included(base)
-        base.send :include, InstanceMethods
-        base.alias_method_chain :assign_attributes, :meta_data
-        base.alias_method_chain :save, :meta_data
-        base.alias_method_chain :post_process_styles, :meta_data
-        base.alias_method_chain :size, :meta_data
+
+      def assign_attributes
+        super
+        assign_meta
       end
 
-      module InstanceMethods
-        def assign_attributes_with_meta_data
-          assign_attributes_without_meta_data
-          assign_meta
+      def save
+        if @queued_for_delete.any? && @queued_for_write.empty?
+          instance_write(:meta, meta_encode({}))
         end
+        super
+      end
 
-        def save_with_meta_data
-          if @queued_for_delete.any? && @queued_for_write.empty?
-            instance_write(:meta, meta_encode({}))
-          end
-          save_without_meta_data
-        end
+      def post_process_styles(*styles)
+        super(*styles)
+        assign_meta
+      end
 
-        def post_process_styles_with_meta_data(*styles)
-          post_process_styles_without_meta_data(*styles)
-          assign_meta
-        end
+      # Use meta info for style if required
+      def size(style = nil)
+        style ? read_meta(style, :size) : super()
+      end
 
-        # Use meta info for style if required
-        def size_with_meta_data(style = nil)
-          style ? read_meta(style, :size) : size_without_meta_data
-        end
+      def height(style = default_style)
+        read_meta style, :height
+      end
 
-        def height(style = default_style)
-          read_meta style, :height
-        end
+      def width(style = default_style)
+        read_meta style, :width
+      end
 
-        def width(style = default_style)
-          read_meta style, :width
-        end
+      def aspect_ratio(style = default_style)
+        width(style).to_f / height(style).to_f
+      end
 
-        def aspect_ratio(style = default_style)
-          width(style).to_f / height(style).to_f
-        end
+      # Return image dimesions ("WxH") for given style name. If style name not given,
+      # return dimesions for default_style.
+      def image_size(style = default_style)
+        "#{width(style)}x#{height(style)}"
+      end
 
-        # Return image dimesions ("WxH") for given style name. If style name not given,
-        # return dimesions for default_style.
-        def image_size(style = default_style)
-          "#{width(style)}x#{height(style)}"
-        end
+      private
 
-        private
+      def assign_meta
+        return unless instance.respond_to?(:"#{name}_meta=")
+        meta = populate_meta(@queued_for_write)
+        return if meta == {}
 
-        def assign_meta
-          return unless instance.respond_to?(:"#{name}_meta=")
+        write_meta(meta)
+      end
 
-          meta = populate_meta(@queued_for_write)
-          return if meta == {}
-
-          write_meta(meta)
-        end
-
-        def populate_meta(queue)
-          meta = {}
-          queue.each do |style, file|
-            begin
-              geo = Geometry.from_file file
-              meta[style] = { width: geo.width.to_i, height: geo.height.to_i, size: file.size }
-            rescue Paperclip::Errors::NotIdentifiedByImageMagickError
-              meta[style] = {}
-            end
-          end
-          meta
-        end
-
-        def write_meta(meta)
-          merge_existing_meta_hash meta
-          instance.send("#{name}_meta=", meta_encode(meta))
-        end
-
-        # Return meta data for given style
-        def read_meta(style, item)
-          if instance.respond_to?(:"#{name}_meta") && instance_read(:meta)
-            if (meta = meta_decode(instance_read(:meta)))
-              meta[style] && meta[style][item]
-            end
+      def populate_meta(queue)
+        meta = {}
+        queue.each do |style, file|
+          begin
+            geo = Geometry.from_file file
+            meta[style] = { width: geo.width.to_i, height: geo.height.to_i, size: file.size }
+          rescue Paperclip::Errors::NotIdentifiedByImageMagickError
+            meta[style] = {}
           end
         end
+        meta
+      end
 
-        # Return encoded metadata as String
-        def meta_encode(meta)
-          Base64.encode64(Marshal.dump(meta))
-        end
+      def write_meta(meta)
+        merge_existing_meta_hash meta
+        instance.send("#{name}_meta=", meta_encode(meta))
+      end
 
-        # Return decoded metadata as Object
-        def meta_decode(meta)
-          Marshal.load(Base64.decode64(meta))
+      # Return meta data for given style
+      def read_meta(style, item)
+        if instance.respond_to?(:"#{name}_meta") && instance_read(:meta)
+          if (meta = meta_decode(instance_read(:meta)))
+            meta[style] && meta[style][item]
+          end
         end
+      end
 
-        # Retain existing meta values that will not be recalculated when
-        # reprocessing a subset of styles
-        def merge_existing_meta_hash(meta)
-          return unless (original_meta = instance.send("#{name}_meta"))
-          meta.reverse_merge! meta_decode(original_meta)
-        end
+      # Return encoded metadata as String
+      def meta_encode(meta)
+        Base64.encode64(Marshal.dump(meta))
+      end
+
+      # Return decoded metadata as Object
+      def meta_decode(meta)
+        Marshal.load(Base64.decode64(meta))
+      end
+
+      # Retain existing meta values that will not be recalculated when
+      # reprocessing a subset of styles
+      def merge_existing_meta_hash(meta)
+        return unless (original_meta = instance.send("#{name}_meta"))
+        meta.reverse_merge! meta_decode(original_meta)
       end
     end
   end

--- a/lib/paperclip-meta/railtie.rb
+++ b/lib/paperclip-meta/railtie.rb
@@ -12,7 +12,7 @@ module Paperclip
 
     class Railtie
       def self.insert
-        Paperclip::Attachment.send(:include, Paperclip::Meta::Attachment)
+        Paperclip::Attachment.prepend Paperclip::Meta::Attachment
       end
     end
   end

--- a/paperclip-meta.gemspec
+++ b/paperclip-meta.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.0.0"
 
-  s.add_dependency "paperclip", "~> 4.0"
+  s.add_dependency "paperclip", "~> 5.0"
 
   s.add_development_dependency "bundler"
   s.add_development_dependency "rake", "~> 11.0"

--- a/paperclip-meta.gemspec
+++ b/paperclip-meta.gemspec
@@ -17,11 +17,12 @@ Gem::Specification.new do |s|
 
   s.add_dependency "paperclip", "~> 4.0"
 
-  s.add_development_dependency "bundler", "~> 1.10"
+  s.add_development_dependency "bundler"
   s.add_development_dependency "rake", "~> 11.0"
   s.add_development_dependency "mocha", "~> 1.0"
   s.add_development_dependency "activerecord", ">= 4.2"
   s.add_development_dependency "sqlite3", ">= 1.3.10"
-  s.add_development_dependency "delayed_paperclip", ">= 2.9.1"
+  s.add_development_dependency "delayed_paperclip", ">= 3.0"
+  s.add_development_dependency "railties"
   s.add_development_dependency "activejob", ">= 4.2"
 end

--- a/paperclip-meta.gemspec
+++ b/paperclip-meta.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "mocha", "~> 1.0"
   s.add_development_dependency "activerecord", ">= 4.2"
   s.add_development_dependency "sqlite3", ">= 1.3.10"
-  s.add_development_dependency "delayed_paperclip", ">= 3.0"
+  s.add_development_dependency "delayed_paperclip", ">= 3.0.1"
   s.add_development_dependency "railties"
   s.add_development_dependency "activejob", ">= 4.2"
 end

--- a/spec/attachment_spec.rb
+++ b/spec/attachment_spec.rb
@@ -131,7 +131,7 @@ describe "Attachment" do
       assert_equal "x", img.big_image.image_size(:large)
 
       job_args = enqueued_jobs.last[:args]
-      job = DelayedPaperclip::Jobs::ActiveJob.new
+      job = DelayedPaperclip::ProcessJob.new
       job.perform(*job_args)
       img.reload
 

--- a/spec/attachment_spec.rb
+++ b/spec/attachment_spec.rb
@@ -43,11 +43,6 @@ describe "Attachment" do
       assert_equal size, @image.big_image.size(:thumb)
     end
 
-    it "should access normal paperclip method when no style passed" do
-      @image.big_image.expects size_without_meta_data: 1234
-      assert_equal 1234, @image.big_image.size
-    end
-
     it "should have access to original file size" do
       assert_equal 37_042, @image.big_image.size
     end

--- a/spec/gemfiles/Gemfile.paperclip-5
+++ b/spec/gemfiles/Gemfile.paperclip-5
@@ -14,4 +14,4 @@ gemspec path: '../..'
 
 gem 'activerecord', '~> 4.2'
 gem 'minitest', '~> 5.3'
-gem 'paperclip', '~> 4.0'
+gem 'paperclip', '~> 5.0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,12 @@
 require "bundler/setup"
+# Paperclip gem requires module#delegate before initialization
+require 'active_support/core_ext/module'
 Bundler.require(:default)
 require 'rails'
 require "active_record"
 require "active_job"
+require "paperclip"
 require "delayed_paperclip"
-require "delayed_paperclip/railtie"
 require "minitest/autorun"
 require "mocha/setup"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,10 @@
 require "bundler/setup"
 Bundler.require(:default)
+require 'rails'
 require "active_record"
 require "active_job"
 require "delayed_paperclip"
+require "delayed_paperclip/railtie"
 require "minitest/autorun"
 require "mocha/setup"
 


### PR DESCRIPTION
Delayed_paperclip 3.0.1 has two changes that break testing the integration with paperclip-meta: it uses ActiveJob, and it uses Module#prepend instead of alias_method_chain.

This pull request also includes changes from #49 — probably makes sense to close that one and make both of these changes at once.

This update should also fix #50 when the newest versions of both gems are used. 
