### PR TITLE
use the kt-paperclip maintained fork

### DIFF
--- a/paperclip-meta.gemspec
+++ b/paperclip-meta.gemspec
@@ -13,9 +13,9 @@ Gem::Specification.new do |s|
   s.files         = Dir["LICENSE.txt", "README.md", "lib/**/*"]
   s.require_paths = ["lib"]
 
-  s.required_ruby_version = ">= 2.2.2"
+  s.required_ruby_version = ">= 2.7"
 
-  s.add_dependency "paperclip", ">= 5.0"
+  s.add_dependency "kt-paperclip", ">= 6.0"
 
   s.add_development_dependency "bundler", "~> 1.13"
   s.add_development_dependency "rake", "~> 12.0"


### PR DESCRIPTION
Paperclip gem is now unmaintained.

But kt-paperclip is

Would you please merge and release this change?

We are using paperclip-meta and our ruby 3.0 upgrade is successful with this change.

Thanks
